### PR TITLE
Add support for separators in values

### DIFF
--- a/fixtures/ps-3.out
+++ b/fixtures/ps-3.out
@@ -1,0 +1,6 @@
+  PID CMD                          STARTED
+ 5971 emacs -nw                     Oct 29
+22678 emacs -nw foo.js            13:10:36
+28752 emacs -nw .                   Oct 28
+31236 emacs -nw fixtures/ps-3.out 17:10:10
+32513 emacs -nw README.md           Oct 28

--- a/index.js
+++ b/index.js
@@ -64,27 +64,36 @@ module.exports = function (str, opts) {
 	var rows = [];
 	var headers = opts.headers;
 	var transform = opts.transform;
+	var els;
 
-	for (var i = 0, els; i < lines.length; i++) {
-		els = splitAt(lines[i], splits, {remove: true});
+	if (!headers) {
+		headers = [];
+		els = splitAt(lines[0], splits, {remove: true});
 
-		if (i !== 0) {
-			var row = {};
-
-			for (var j = 0, el, header; j < headers.length; j++) {
-				el = (els[j] || '').trim();
-				header = headers[j];
-				row[header] = transform ? transform(el, header, j, i) : el;
-			}
-
-			rows.push(row);
-		} else if (!headers) {
-			headers = [];
-
-			for (var j2 = 0; j2 < els.length; j2++) {
-				headers.push(els[j2].trim());
+		for (var index = 0, el; index < els.length; ++index) {
+			el = els[index].trim();
+			if (el) {
+				headers.push(el);
+			} else {
+				splits[index - 1] = null;
 			}
 		}
+
+		splits = splits.filter(Boolean);
+	}
+
+	for (var i = 1; i < lines.length; i++) {
+		els = splitAt(lines[i], splits, {remove: true});
+
+		var row = {};
+
+		for (var j = 0, el, header; j < headers.length; j++) {
+			el = (els[j] || '').trim();
+			header = headers[j];
+			row[header] = transform ? transform(el, header, j, i) : el;
+		}
+
+		rows.push(row);
 	}
 
 	return rows;

--- a/test.js
+++ b/test.js
@@ -5,6 +5,7 @@ var parseColumns = require('./');
 var fixture = fs.readFileSync('fixtures/ps.out', 'utf8');
 var fixture2 = fs.readFileSync('fixtures/ps-2.out', 'utf8');
 var fixture3 = fs.readFileSync('fixtures/lsof.out', 'utf8');
+var fixture4 = fs.readFileSync('fixtures/ps-3.out', 'utf8');
 
 test('parse', function (t) {
 	var f = parseColumns(fixture);
@@ -51,6 +52,40 @@ test('differing line lengths', function (t) {
 			return row.hasOwnProperty(key);
 		});
 	}));
+
+	t.end();
+});
+
+test('separators in values', function (t) {
+	var f = parseColumns(fixture4);
+
+	t.same(f, [
+		{
+			PID: '5971',
+			CMD: 'emacs -nw',
+			STARTED: 'Oct 29'
+		},
+		{
+			PID: '22678',
+			CMD: 'emacs -nw foo.js',
+			STARTED: '13:10:36'
+		},
+		{
+			PID: '28752',
+			CMD: 'emacs -nw .',
+			STARTED: 'Oct 28'
+		},
+		{
+			PID: '31236',
+			CMD: 'emacs -nw fixtures/ps-3.out',
+			STARTED: '17:10:10'
+		},
+		{
+			PID: '32513',
+			CMD: 'emacs -nw README.md',
+			STARTED: 'Oct 28'
+		}
+	]);
 
 	t.end();
 });


### PR DESCRIPTION
This patch adds support for separators in values by merging each column with an empty header with a preceding column.

For example, for this input (taken from #6):

```
CMD                           PID  STARTED
emacs -nw .                 29920   Oct 16
```

the following potential split points are calculated as before:

```
CMD  |   | |                  PID| STARTED
emacs|-nw|.|                29920|  Oct 16
```

but then columns 1 and 2 get merged with the column 0 and the final split follows:

```
CMD        |                  PID| STARTED
emacs -nw .|                29920|  Oct 16
```

Fix #6.
